### PR TITLE
Reloadr performance improvements

### DIFF
--- a/reloadr.py
+++ b/reloadr.py
@@ -4,6 +4,7 @@
 
 from os.path import dirname, abspath
 import inspect
+import logging
 import redbaron
 from baron.parser import ParsingError
 import threading
@@ -124,8 +125,9 @@ class ClassReloadr(GenericReloadr):
                 instance = ref()  # We keep weak references to objects
                 if instance:
                     instance.__class__ = self._target
+            logging.info('Reloaded {}'.format(self._target.__name__))
         except ParsingError as error:
-            print('ParsingError', error)
+            logging.error('Parsing error: {}'.format(error))
 
 
 class FuncReloadr(GenericReloadr):
@@ -148,7 +150,7 @@ class FuncReloadr(GenericReloadr):
         try:
             self._target = reload_function(self._target, self._filepath)
         except ParsingError as error:
-            print('ParsingError', error)
+            logging.error('Parsing error: {}'.format(error))
 
 
 def reloadr(target):

--- a/reloadr.py
+++ b/reloadr.py
@@ -86,10 +86,9 @@ class GenericReloadr:
 
         class EventHandler(FileSystemEventHandler):
             def on_modified(self, event):
-                this._reload()
+                if not event.is_directory and event.src_path == filepath:
+                    this._reload()
 
-        # Sadly, watchdog only operates on directories and not on a file
-        # level, so any change within the directory will trigger a reload.
         observer.schedule(EventHandler(), filedir, recursive=False)
         observer.start()
 


### PR DESCRIPTION
- Prevent file reloads on any directory change
- Prevent multiple watchers to reduce redundant reloads
    - This is done by removing the decorator before code execution
    - Significant performance gain - previously the number of reloads was increasing exponentially
- Add logging
- Increment version and use triple quotes for docstrings